### PR TITLE
Fix case of Unzipper.exe

### DIFF
--- a/OpenUtau/Resources/Resources.resx
+++ b/OpenUtau/Resources/Resources.resx
@@ -119,6 +119,6 @@
   </resheader>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="Unzipper" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>unzipper.exe;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>Unzipper.exe;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
 </root>


### PR DESCRIPTION
Fix case of Unzipper.exe reference for case-sensitive platforms (eg. Linux)